### PR TITLE
On récupère les règles sur un CDN

### DIFF
--- a/source/Provider.js
+++ b/source/Provider.js
@@ -69,7 +69,7 @@ export default class Provider extends PureComponent {
 		return (
 			// If IE < 11 display nothing
 			<ReduxProvider store={this.store}>
-				<RulesProvider rulesConfig={this.props.rulesConfig}>
+				<RulesProvider rulesURL={this.props.rulesURL}>
 					<ThemeColoursProvider colour={getIframeOption('couleur')}>
 						<TrackerProvider value={this.props.tracker}>
 							<SitePathProvider value={this.props.sitePaths}>

--- a/source/RulesProvider.js
+++ b/source/RulesProvider.js
@@ -25,18 +25,12 @@ export default connect(
 			super(props)
 
 			if (process.env.NODE_ENV === 'development') {
-				import('../../futureco-data/co2.yaml').then(src => {
+				import('../../data/co2.yaml').then(src => {
 					this.props.setRules(src.default)
 					this.removeLoader()
 				})
 			} else {
-				fetch(
-					'https://publicodes.netlify.com/.netlify/functions/getRulesFile?' +
-						toPairs(props.rulesConfig.fetch)
-							.map(([k, v]) => k + '=' + v)
-							.join('&'),
-					{ mode: 'cors' }
-				)
+				fetch(props.rulesURL, { mode: 'cors' })
 					.then(response => response.json())
 					.then(json => {
 						this.props.setRules(json)

--- a/source/sites/publicodes/App.js
+++ b/source/sites/publicodes/App.js
@@ -21,12 +21,7 @@ class App extends Component {
 		return (
 			<Provider
 				basename="publicodes"
-				rulesConfig={{
-					fetch: {
-						repo: 'laem/futureco-data',
-						filePath: 'co2.yaml'
-					}
-				}}
+				rulesURL="https://futureco-data.netlify.com/co2.json"
 				sitePaths={sitePaths()}
 				reduxMiddlewares={[]}>
 				<StoreProvider>


### PR DESCRIPTION
Beaucoup plus rapide que l'ancienne fonction netlify qui prenait 1.6 à
servir les règles à cause de l'appel à github, qui n'est pas fait pour
ça.

Fixes #44 