### PR TITLE
Ajout d'une catégorie "meuble"

### DIFF
--- a/source/components/categories.js
+++ b/source/components/categories.js
@@ -1,6 +1,7 @@
 const catégories = [
 	'transport',
 	'logement',
+	'meubles',
 	'numérique',
 	'vêtements',
 	'divers',


### PR DESCRIPTION
Suite à l'ajout de nouveaux modèles d'impact carbone de la catégorie meuble (cf https://github.com/laem/futureco-data/pull/114#issuecomment-1188786591),  je rajoute une nouvelle catégorie "meuble"