### PR TITLE
Une autre catégorie d'hebergement tourisme différente du gite

### DIFF
--- a/app/voyage/categories.yaml
+++ b/app/voyage/categories.yaml
@@ -69,7 +69,7 @@
     - hébergement
     - nuit
     - dormir
-  query: '["tourism"~"hotel|chalet|guest_house"]'
+  query: '["tourism"~"hotel|chalet|guest_house|apartment"]'
   open by default: true
   icon: https://cdn.jsdelivr.net/gh/mapbox/maki/icons/lodging.svg
 - name: vue


### PR DESCRIPTION
Il existe une dernière catégorie qui est décrite sur cette page wiki: https://wiki.openstreetmap.org/wiki/FR:Tag:tourism%3Dapartment

différente du gîte et du chalet donc et surement interressante à afficher en même temps que les Hôtels. ;-)