### PR TITLE
Proposition d'extension de la catégorie parc (verdure, jardin, square)

### DIFF
--- a/app/voyage/categories.yaml
+++ b/app/voyage/categories.yaml
@@ -41,7 +41,9 @@
     - verdure
     - jardin
     - square
-  query: '[leisure=park]'
+  query: 
+    -'[leisure=park|nature_reserve]'
+    -'[boundary=national_park]'
   icon: tree
   open by default: true
 - name: bus


### PR DESCRIPTION
Proposition d'extension de la catégorie parc 'municipaux' au réserves et 'parc nationaux'.

Ces derniers sont souvent ouverts aux piétons et proposent des circuits de balades ou randos.