### PR TITLE
correctif url api panoramax dans Update ZoneImages.tsx

### DIFF
--- a/app/voyage/ZoneImages.tsx
+++ b/app/voyage/ZoneImages.tsx
@@ -103,7 +103,7 @@ export function ZoneImages({ zoneImages: images, panoramaxImages }) {
 				>
 					{panoramaxThumb && (
 						<a
-							href={`https://panoramax.fr/photos#focus=pic&map=${window.location.hash.slice(
+							href={`https://api.panoramax.xyz/#focus=pic&map=${window.location.hash.slice(
 								1
 							)}&pic=${panoramaxImage.id}`}
 							target="_blank"


### PR DESCRIPTION
l'url de l'api pour afficher les images avec l'UUID est 'https://api.panoramax.xyz'

voir le message:
https://forum.openstreetmap.fr/t/uuid-panoramax-comment-lutiliser/20482/3?u=u4y0u