### PR TITLE
Affichage optimisé des cartes de transport

### DIFF
--- a/app/voyage/effects/useDrawTransport.ts
+++ b/app/voyage/effects/useDrawTransport.ts
@@ -1,7 +1,189 @@
 import useSetSearchParams from '@/components/useSetSearchParams'
+import { keys } from '@/components/utils/utils'
+import { featureCollection } from '@turf/turf'
 import { useEffect } from 'react'
 
-const mergeRoutes = (geojson) => {
+/***
+ * This hook draws transit lines on the map.
+ */
+export default function useDrawTransport(
+	map,
+	entries: Array<string, object>,
+	styleKey,
+	sourcePrefix
+) {
+	const setSearchParams = useSetSearchParams()
+
+	useEffect(() => {
+		if (!map || !entries) return
+
+		const sources = Object.entries(map.getStyle().sources).filter(
+			([sourceId]) => sourceId.startsWith(sourcePrefix)
+		)
+
+		const sourcesToRemove = sources.filter(([sourceId]) => {
+			const found = entries.find(([id]) => sourceId === sourcePrefix + id)
+
+			return !found
+		})
+		sourcesToRemove.forEach(([id]) => {
+			// TODO we could also just remove the layer but not the source. It's a
+			// tradeoff, since I guess keeping a source holds memory for an incertain
+			// future, but spares GPU time
+			map.removeLayer(id + '-lines')
+			map.removeLayer(id + '-points')
+			map.removeSource(id)
+		})
+
+		console.log('indigo entries ', keys(entries))
+		console.log('indigo map sources', keys(sources))
+		console.log('indigo to remove', keys(sourcesToRemove))
+
+		entries.map(([drawKey, featureCollection]) => {
+			const id = sourcePrefix + drawKey
+			try {
+				const source = map.getSource(id)
+				if (source) return
+				console.log('indigo will add source', id)
+				map.addSource(id, { type: 'geojson', data: featureCollection })
+
+				const linesId = id + '-lines'
+
+				map.addLayer({
+					source: id,
+					type: 'line',
+					id: linesId,
+					filter: [
+						'all',
+						['in', '$type', 'LineString'],
+						['has', 'route_color'],
+					],
+					layout: {
+						'line-join': 'round',
+						'line-cap': 'round',
+					},
+					paint: {
+						// In Rennes, one crazy bus network is the football stadium route, code E4
+						// Since the agency did not give it colors, it's hard to draw it on a map
+						// Moreover, it should be handled as an exceptional bus, not a regular one
+						// This is easy to check through the data, see that it runs only on selected
+						// days / hours and display it to the user TODO
+						'line-color': ['get', 'route_color'],
+						'line-opacity': ['get', 'opacity'],
+						'line-width': [
+							'let',
+							'importance',
+							[
+								'match',
+								['get', 'route_type'],
+								0,
+								1.6,
+								1,
+								2.6,
+								2,
+								3,
+								3,
+								0.8,
+								0.8,
+							],
+							[
+								'interpolate',
+								['linear', 1],
+								['zoom'],
+								3,
+								['*', ['var', 'importance'], 0.2],
+								12,
+								['*', ['var', 'importance'], 2.5],
+								18,
+								['*', ['var', 'importance'], 4],
+							],
+						],
+					},
+				})
+				const pointsId = id + '-points'
+				map.addLayer({
+					source: id,
+					type: 'circle',
+					id: pointsId,
+					filter: ['in', '$type', 'Point'],
+					paint: {
+						'circle-radius': [
+							'interpolate',
+							['linear', 1],
+							['zoom'],
+							0,
+							['*', 10, ['get', 'width']],
+							12,
+							['*', 20, ['get', 'width']],
+							18,
+							['*', 50, ['get', 'width']],
+						],
+						'circle-stroke-width': [
+							'interpolate',
+							['linear', 1],
+							['zoom'],
+							0,
+							['*', 2, ['get', 'width']],
+							12,
+							['*', 5, ['get', 'width']],
+							18,
+							['*', 10, ['get', 'width']],
+						],
+						'circle-stroke-color': ['get', 'circle-stroke-color'],
+
+						'circle-pitch-alignment': 'map',
+						'circle-color': ['get', 'circle-color'],
+					},
+				})
+
+				map.on('click', linesId, (e) => {
+					setSearchParams({
+						routes: e.features
+							.map((feature) => feature.properties.routeId)
+							.join('|'),
+					})
+				})
+				map.on('click', pointsId, (e) => {
+					console.log('click', e)
+					const feature = e.features[0],
+						stopId = feature.properties.stopId,
+						gare = stopId.split('-').slice(-1)[0]
+
+					setSearchParams({
+						gare,
+					})
+				})
+
+				map.on('mouseenter', linesId, () => {
+					map.getCanvas().style.cursor = 'pointer'
+				})
+				// Change it back to a pointer when it leaves.
+				map.on('mouseleave', linesId, () => {
+					map.getCanvas().style.cursor = 'auto'
+				})
+			} catch (e) {
+				console.log('Caught error drawing useDrawTransport', e)
+			}
+		})
+
+		return () => {
+			return // this would delete then re-render on each agency list change
+			entries.map(([id]) => {
+				try {
+					map.removeLayer(id + '-lines')
+					map.removeLayer(id + '-points')
+					const source = map.getSource(id)
+					if (source) {
+						map.removeSource(id)
+					}
+				} catch (e) {
+					console.log('Caught error undrawing useDrawTransport', e)
+				}
+			})
+		}
+	}, [map, entries, styleKey, setSearchParams])
+}
+function mergeRoutes(geojson) {
 	// TODO I can't yet understand why so many geojsons for one route, and how to
 	// draw them correctly.
 	// Iterating on client for now, then will be cached on the server
@@ -30,177 +212,4 @@ const mergeRoutes = (geojson) => {
 		.filter(Boolean)
 
 	return { ...geojson, features }
-}
-/***
- * This hook draws transit lines on the map.
- */
-export default function useDrawTransport(map, data, styleKey, drawKey, day) {
-	const routesGeojson = data?.routesGeojson
-
-	const setSearchParams = useSetSearchParams()
-
-	useEffect(() => {
-		if (!map || !routesGeojson) return
-
-		/* Lower the opacity of all style layers.
-		 * Replaced by setting the "transit" style taken from MapTiler's dataviz
-		 * clean styl, but we're losing essential
-		 * things like POIs, might be interesting to consider this option, or
-		 * alternatively make the dataviz style better
-		 *
-		const layerIds = map.getLayersOrder()
-		layerIds.map((layerId) => {
-			if (layerId.startsWith('routes-stopId-')) return
-			const layer = map.getLayer(layerId)
-			const property =
-				layer.type === 'fill'
-					? ['fill-opacity']
-					: layer.type === 'background'
-					? ['background-opacity']
-					: layer.type === 'line'
-					? ['line-opacity']
-					: layer.type === 'symbol'
-					? ['text-opacity', 'icon-opacity']
-					: null
-			if (property) property.map((p) => map.setPaintProperty(layerId, p, 0.3))
-		})
-		*/
-		const featureCollection =
-			routesGeojson.type === 'FeatureCollection'
-				? mergeRoutes(routesGeojson)
-				: routesGeojson.reduce(
-						(memo, next) => ({
-							type: 'FeatureCollection',
-							features: [
-								...memo.features,
-								...(next.shapes?.features || next.features),
-								...(next.stops?.features.map((f) => ({
-									...f,
-									properties: { route_color: '#' + next.route.route_color },
-								})) || []),
-							],
-						}),
-						{ features: [] }
-				  )
-		const id = 'routes-stopId-' + drawKey
-		try {
-			const source = map.getSource(id)
-			if (source) return
-			map.addSource(id, { type: 'geojson', data: featureCollection })
-
-			const linesId = id + '-lines'
-
-			map.addLayer({
-				source: id,
-				type: 'line',
-				id: linesId,
-				filter: ['all', ['in', '$type', 'LineString'], ['has', 'route_color']],
-				layout: {
-					'line-join': 'round',
-					'line-cap': 'round',
-				},
-				paint: {
-					// In Rennes, one crazy bus network is the football stadium route, code E4
-					// Since the agency did not give it colors, it's hard to draw it on a map
-					// Moreover, it should be handled as an exceptional bus, not a regular one
-					// This is easy to check through the data, see that it runs only on selected
-					// days / hours and display it to the user TODO
-					'line-color': ['get', 'route_color'],
-					'line-opacity': ['get', 'opacity'],
-					'line-width': [
-						'let',
-						'importance',
-						['match', ['get', 'route_type'], 0, 1.6, 1, 2.6, 2, 3, 3, 0.8, 0.8],
-						[
-							'interpolate',
-							['linear', 1],
-							['zoom'],
-							3,
-							['*', ['var', 'importance'], 0.2],
-							12,
-							['*', ['var', 'importance'], 2.5],
-							18,
-							['*', ['var', 'importance'], 4],
-						],
-					],
-				},
-			})
-			const pointsId = id + '-points'
-			map.addLayer({
-				source: id,
-				type: 'circle',
-				id: pointsId,
-				filter: ['in', '$type', 'Point'],
-				paint: {
-					'circle-radius': [
-						'interpolate',
-						['linear', 1],
-						['zoom'],
-						0,
-						['*', 10, ['get', 'width']],
-						12,
-						['*', 20, ['get', 'width']],
-						18,
-						['*', 50, ['get', 'width']],
-					],
-					'circle-stroke-width': [
-						'interpolate',
-						['linear', 1],
-						['zoom'],
-						0,
-						['*', 2, ['get', 'width']],
-						12,
-						['*', 5, ['get', 'width']],
-						18,
-						['*', 10, ['get', 'width']],
-					],
-					'circle-stroke-color': ['get', 'circle-stroke-color'],
-
-					'circle-pitch-alignment': 'map',
-					'circle-color': ['get', 'circle-color'],
-				},
-			})
-
-			map.on('click', linesId, (e) => {
-				setSearchParams({
-					routes: e.features
-						.map((feature) => feature.properties.routeId)
-						.join('|'),
-				})
-			})
-			map.on('click', pointsId, (e) => {
-				console.log('click', e)
-				const feature = e.features[0],
-					stopId = feature.properties.stopId,
-					gare = stopId.split('-').slice(-1)[0]
-
-				setSearchParams({
-					gare,
-				})
-			})
-
-			map.on('mouseenter', linesId, () => {
-				map.getCanvas().style.cursor = 'pointer'
-			})
-			// Change it back to a pointer when it leaves.
-			map.on('mouseleave', linesId, () => {
-				map.getCanvas().style.cursor = 'auto'
-			})
-		} catch (e) {
-			console.log('Caught error drawing useDrawTransport', e)
-		}
-
-		return () => {
-			try {
-				map.removeLayer(id + '-lines')
-				map.removeLayer(id + '-points')
-				const source = map.getSource(id)
-				if (source) {
-					map.removeSource(id)
-				}
-			} catch (e) {
-				console.log('Caught error undrawing useDrawTransport', e)
-			}
-		}
-	}, [map, routesGeojson, drawKey, styleKey])
 }

--- a/components/utils/utils.ts
+++ b/components/utils/utils.ts
@@ -124,3 +124,7 @@ export const objectMapEntries = (obj, fn, filterBoolean) => {
 	const filteredEntries = filterBoolean ? entries.filter(Boolean) : entries
 	return Object.fromEntries(filteredEntries)
 }
+
+export function keys(entries: Array<[string, any]>) {
+	return entries.map(([key]) => key)
+}


### PR DESCRIPTION
Dans le hook useDrawTransport, on va faire un loop sur les agences pour
les rendre dans leur source maplibre propre. Ainsi, quand une agence
s'ajoute, on l'ajoute sans redessiner toutes les autres.

Le useEffect devra être rerendu quand la liste des agences change, mais
un check hasSource devra être fait, et le nettoyage du hook fait
correctement également pour enlever ce qui a été dessiné.

- [ ] on a bien trituré useDrawTransport, il faut rétablir son fonctionnement avec ses usages initiaux, l'affichage des routes au clic sur un arrêt
- [ ] faire marcher le clic sur une route pour voir la route
-[ ] https://x.com/LCIwan/status/1769098249523057014?s=20
