### PR TITLE
add link to PlayGuide website in case the feature is a playground

### DIFF
--- a/app/voyage/OsmFeature.tsx
+++ b/app/voyage/OsmFeature.tsx
@@ -13,6 +13,10 @@ import Stop, { isNotTransportStop, transportKeys } from './transport/stop/Stop'
 export default function OsmFeature({ data, transportStopData }) {
 	if (!data.tags) return null
 	console.log('tags', data.tags)
+
+	const id = data.id
+	const featureType = data.type || data.featureType
+
 	const {
 		name,
 		description,
@@ -32,6 +36,7 @@ export default function OsmFeature({ data, transportStopData }) {
 		'brand:wikidata': brandWikidata,
 		'brand:wikipedia': brandWikipedia,
 		'ref:FR:Allocine': allocine,
+		'leisure': leisure,
 		'ref:mhs': mérimée,
 		wikipedia,
 		wikidata,
@@ -121,6 +126,15 @@ export default function OsmFeature({ data, transportStopData }) {
 					title="Lien vers la fiche cinéma sur Allocine"
 				>
 					Fiche Allociné
+				</a>
+			)}
+			{leisure && leisure=='playground' && (
+				<a
+					href={`https://playguide.eu/app/osm/${featureType}/${id}`}
+					target="_blank"
+					title="Lien vers la fiche de l'aire sur PlayGuide"
+				>
+					Fiche PlayGuide
 				</a>
 			)}
 			<Brand {...{ brand, brandWikidata, brandWikipedia }} />

--- a/app/voyage/OsmFeature.tsx
+++ b/app/voyage/OsmFeature.tsx
@@ -17,6 +17,12 @@ export default function OsmFeature({ data, transportStopData }) {
 	const id = data.id
 	const featureType = data.type || data.featureType
 
+	// Copy tags here that could be important to qualify the object with icons :
+	// they should not be extracted, just copied
+
+	const { leisure } = data.tags
+	// Extract here tags that do not qualify the object : they won't be available
+	// anymore in `rest`
 	const {
 		name,
 		description,
@@ -36,7 +42,6 @@ export default function OsmFeature({ data, transportStopData }) {
 		'brand:wikidata': brandWikidata,
 		'brand:wikipedia': brandWikipedia,
 		'ref:FR:Allocine': allocine,
-		'leisure': leisure,
 		'ref:mhs': mérimée,
 		wikipedia,
 		wikidata,
@@ -128,7 +133,7 @@ export default function OsmFeature({ data, transportStopData }) {
 					Fiche Allociné
 				</a>
 			)}
-			{leisure && leisure=='playground' && (
+			{leisure && leisure == 'playground' && (
 				<a
 					href={`https://playguide.eu/app/osm/${featureType}/${id}`}
 					target="_blank"

--- a/app/voyage/OsmFeature.tsx
+++ b/app/voyage/OsmFeature.tsx
@@ -9,6 +9,7 @@ import parseOpeningHours from 'opening_hours'
 import { getTagLabels } from './osmTagLabels'
 import Brand, { Wikidata } from './tags/Brand'
 import Stop, { isNotTransportStop, transportKeys } from './transport/stop/Stop'
+import Image from 'next/image'
 
 export default function OsmFeature({ data, transportStopData }) {
 	if (!data.tags) return null
@@ -138,7 +139,22 @@ export default function OsmFeature({ data, transportStopData }) {
 					href={`https://playguide.eu/app/osm/${featureType}/${id}`}
 					target="_blank"
 					title="Lien vers la fiche de l'aire sur PlayGuide"
+					css={`
+						display: flex;
+						align-items: center;
+						img {
+							margin-right: 0.6rem;
+							width: 1.2rem;
+							height: auto;
+						}
+					`}
 				>
+					<Image
+						src="https://playguide.eu/assets/logo-pentagon.svg"
+						alt="Logo du site PlayGuide"
+						width="10"
+						height="10"
+					/>
 					Fiche PlayGuide
 				</a>
 			)}


### PR DESCRIPTION
Dans le cas où le feature est une aire de jeux (leisure=playground) : ajout d'un lien vers la fiche de l'aire de jeux sur l'annuaire PlayGuide.
J'ai dû récupérer l'id et le type de l'élément osm pour créer le lien, car ils n'étaient pas disponibles dans l'OsmFeature, je ne sais pas si c'était la bonne façon de faire, ou si j'aurais dû créer un fichier spécifique comme pour OsmLinks ?