### PR TITLE
Proposition amélioration query coworking

### DIFF
--- a/app/voyage/moreCategories.yaml
+++ b/app/voyage/moreCategories.yaml
@@ -290,7 +290,9 @@
 - title: Espace de cotravail (coworking)
   category: Divers
   name: cotravail
-  query: '[amenity=coworking_space]'
+  query:
+    - '[amenity=coworking_space]'
+    - '[office=coworking]'
   icon: coworking
 - title: Cordonnier
   category: Divers


### PR DESCRIPTION
Les 'espaces de coworking'  sont identifiés de deux façons différentes actuellement dans OSM. Cette requête modifiée permet de faire remonter toutes les réponses existantes dans la base de données d'OSM.