### PR TITLE
Proposition ajout casier à colis

### DIFF
--- a/app/voyage/moreCategories.yaml
+++ b/app/voyage/moreCategories.yaml
@@ -267,6 +267,15 @@
     - shopping
   query: '[shop=mall]'
   icon: shop
+- name: Casier à Colis 
+  category: Commerces
+  dictionary:
+    - locker
+    - pickup
+    - colis
+  query: '[amenity=parcel_locker]'
+  icon: parcel_locker
+################################
 
 - name: Police
   category: Divers

--- a/app/voyage/moreCategories.yaml
+++ b/app/voyage/moreCategories.yaml
@@ -110,7 +110,7 @@
     - terrain de jeu
     - manège
     - aire de jeu
-  query: 
+  query:
     - '[leisure=playground]'
     - '[landuse=recreation_ground]'
     - '[attraction=carousel]'
@@ -267,7 +267,7 @@
     - shopping
   query: '[shop=mall]'
   icon: shop
-- name: Casier à Colis 
+- name: Casier à Colis
   category: Commerces
   dictionary:
     - locker

--- a/public/icons/parcel_locker.svg
+++ b/public/icons/parcel_locker.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M36.5528 9.10557L40 16V36C40 38.2091 38.2091 40 36 40H12C9.79086 40 8 38.2091 8 36V16L11.4472 9.10557C11.786 8.428 12.4785 8 13.2361 8H34.7639C35.5215 8 36.214 8.428 36.5528 9.10557ZM12.4721 16L14.4721 12H33.5279L35.5279 16H12.4721ZM12 20V36H36V20H12Z" fill="white"/>
+<path opacity="0.7" d="M22 8H26L28 20V32L24 28L20 30V20L22 8Z" fill="white"/>
+</svg>


### PR DESCRIPTION
Permet de repérer le casier à colis le plus près de son domicile ou de sa position dans la catégorie Commerces existante.