### PR TITLE
🐛 Fix wrong tag translation for object types

### DIFF
--- a/app/voyage/osmTagLabels.ts
+++ b/app/voyage/osmTagLabels.ts
@@ -12,7 +12,17 @@ export const getTagLabels = (key, value) => {
 
 	const values = value.split(';'),
 		translatedValues = values.map(
-			(v) => field.options?.[v] || translateBasics(v)
+			(v) => {
+				const optionValue = field.options?.[v]
+				switch (typeof optionValue) {
+					case 'string':
+						return optionValue
+					case 'object':
+						if (optionValue.title) return optionValue.title
+					default:
+						return translateBasics(v)
+				}
+			}
 		)
 	return [field.label, translatedValues.join(' - ')]
 }


### PR DESCRIPTION
Fixes https://github.com/laem/futureco/issues/252

Le probleme vient du fait que les values de `options` (dans le json preset fr) ne sont pas toujours des strings:
```
"options": {
    "customers": {
        "description": "Accès restreint aux clients à l'arrivée",
        "title": "Clients"
    },
    ...
}
```

vs :
```
"options": {
    "customers": "Réservé à la clientèle",
    ...
}
```

J'ai utilisé title, lorsque dispo, mais peut etre que description serait mieux ? 🤔 